### PR TITLE
Update kata's PHP version

### DIFF
--- a/PHP/composer.json
+++ b/PHP/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Test\\": "test"
+            "Tests\\": "tests"
         }
     },
     "scripts": {

--- a/PHP/composer.json
+++ b/PHP/composer.json
@@ -7,7 +7,9 @@
             "name": "Görge Albrecht"
         }
     ],
-    "require": {},
+    "require": {
+        "php": "^8.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "8.5.*",
         "mockery/mockery": "1.4.*"

--- a/PHP/composer.json
+++ b/PHP/composer.json
@@ -11,8 +11,8 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "8.5.*",
-        "mockery/mockery": "1.4.*"
+        "phpunit/phpunit": "^9.1|^10.0|^11.0",
+        "mockery/mockery": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/PHP/phpunit.xml
+++ b/PHP/phpunit.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-    bootstrap="./vendor/autoload.php"
-	colors="true"
-	beStrictAboutChangesToGlobalState="true"
-	beStrictAboutOutputDuringTests="true"
-	beStrictAboutResourceUsageDuringSmallTests="true"
-	beStrictAboutTestsThatDoNotTestAnything="false"
-	beStrictAboutTodoAnnotatedTests="true"
-	beStrictAboutCoversAnnotation="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-	verbose="true">
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         beStrictAboutChangesToGlobalState="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutResourceUsageDuringSmallTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         beStrictAboutTodoAnnotatedTests="true"
+         beStrictAboutCoversAnnotation="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         verbose="true">
 
-	<filter>
-	  <whitelist processUncoveredFilesFromWhitelist="true">
-	    <directory suffix=".php">src</directory>
-	  </whitelist>
-	</filter>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 
-	<testsuites>
-		<testsuite name="All Tests">
-			<directory suffix="_test.php">test</directory>
-			<directory suffix="Test.php">test</directory>
-		</testsuite>
-	</testsuites>
+    <testsuites>
+        <testsuite name="All Tests">
+            <directory suffix="_test.php">test</directory>
+            <directory suffix="Test.php">test</directory>
+        </testsuite>
+    </testsuites>
 
-	<logging>
-		<log type="coverage-html" target="./coverage" />
-	</logging>
+    <logging>
+        <log type="coverage-html" target="./coverage"/>
+    </logging>
 </phpunit>

--- a/PHP/phpunit.xml
+++ b/PHP/phpunit.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-	backupGlobals="false"
+<phpunit backupGlobals="false"
     bootstrap="./vendor/autoload.php"
 	colors="true"
 	beStrictAboutChangesToGlobalState="true"

--- a/PHP/src/DeviceDriver.php
+++ b/PHP/src/DeviceDriver.php
@@ -31,12 +31,12 @@ class DeviceDriver
         $this->hardware = $hardware;
     }
 
-    public function read($address)
+    public function read(int $address): int
     {
         return $this->hardware->read($address);
     }
 
-    public function write($address, $data)
+    public function write(int $address, int $data): void
     {
         $start = hrtime(false)[1];
         $this->hardware->write(self::INIT_ADDRESS, self::PROGRAM_COMMAND);

--- a/PHP/src/DeviceDriver.php
+++ b/PHP/src/DeviceDriver.php
@@ -6,7 +6,7 @@ namespace DeviceDriver;
 
 /**
  * This class is used by the operating system to interact
- * with the hardware 'FlashMemoryDevice'.
+ * with the hardware 'FlashMemoryDevice'. @see FlashMemoryDevice
  */
 class DeviceDriver
 {

--- a/PHP/src/DeviceDriver.php
+++ b/PHP/src/DeviceDriver.php
@@ -41,6 +41,7 @@ class DeviceDriver
         $start = hrtime(false)[1];
         $this->hardware->write(self::INIT_ADDRESS, self::PROGRAM_COMMAND);
         $this->hardware->write($address, $data);
+
         $readyByte = 0;
         while ((($readyByte = $this->read(self::INIT_ADDRESS)) & self::READY_MASK) == 0) {
             if ($readyByte != self::READY_NO_ERROR) {
@@ -59,6 +60,7 @@ class DeviceDriver
                 throw new TimeoutException("Timeout when trying to read data from memory");
             }
         }
+
         $actual = $this->read($address);
         if ($data != $actual) {
             throw new ReadFailureException("Failed to read data from memory");

--- a/PHP/src/DeviceDriver.php
+++ b/PHP/src/DeviceDriver.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace DeviceDriver;
 
 /**

--- a/PHP/src/FlashMemoryDevice.php
+++ b/PHP/src/FlashMemoryDevice.php
@@ -10,7 +10,7 @@ namespace DeviceDriver;
  */
 interface FlashMemoryDevice
 {
-    function read($address);
+    public function read(int $address): int;
 
-    function write($address, $data);
+    public function write(int $address, int $data): void;
 }

--- a/PHP/src/FlashMemoryDevice.php
+++ b/PHP/src/FlashMemoryDevice.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace DeviceDriver;
 
 /**

--- a/PHP/src/FlashMemoryDevice.php
+++ b/PHP/src/FlashMemoryDevice.php
@@ -10,7 +10,16 @@ namespace DeviceDriver;
  */
 interface FlashMemoryDevice
 {
+    /**
+     * @param int $address
+     * @return int
+     */
     public function read(int $address): int;
 
+    /**
+     * @param int $address
+     * @param int $data
+     * @return void
+     */
     public function write(int $address, int $data): void;
 }

--- a/PHP/tests/DeviceDriverTest.php
+++ b/PHP/tests/DeviceDriverTest.php
@@ -1,5 +1,6 @@
 <?php
-namespace Test;
+
+namespace Tests;
 
 use DeviceDriver\DeviceDriver;
 use DeviceDriver\FlashMemoryDevice;


### PR DESCRIPTION
Hello,

Thanks for the kata. That was an interesting one :)

I would like to propose a few changes to the PHP version:
- bump PHP and its dependencies (`8.0` is already deprecated, but some people still use it, or I can increase the version to `8.1`)
- add parameter types and return types to method signatures in the interface and main class (and add `strict_types` directive)
- change the tests location to `tests` (it does make more sense to me because we are supposed to write multiple tests)
- update `phpunit.xml` formatting and remove XML schema (because different versions of phpunit are now available)
- some style improvements

